### PR TITLE
fix(dprint): exclude generated build/dist/static directories from formatting

### DIFF
--- a/dprint.json
+++ b/dprint.json
@@ -17,7 +17,13 @@
   "includes": ["**/*.{ts,tsx,js,jsx,cjs,mjs,json,md}"],
   "excludes": [
     "**/node_modules",
-    "**/*-lock.json"
+    "**/*-lock.json",
+    "**/build",
+    "**/dist",
+    "**/.vite",
+    "src/main/resources/static",
+    "**/test-results",
+    "**/playwright-report"
   ],
   "plugins": [
     "https://plugins.dprint.dev/typescript-0.77.0.wasm",


### PR DESCRIPTION
## Summary
- dprint's includes glob was matching minified Vite bundles, gradle build output, and Spring Boot's staged static dir, causing `dprint fmt` to OOM on consumers (reproducible crash where the kernel OOM killer reaps the parent shell on a no-cgroup-limit host).
- Added excludes for `**/build`, `**/dist`, `**/.vite`, `src/main/resources/static`, `**/test-results`, `**/playwright-report`.

## Root cause
The TypeScript plugin (0.77.0) parses each matched file into an AST. A 1.7 MB single-line minified bundle (e.g. \`build/resources/main/static/app/assets/index-*.js\` produced by gradle's bootJar staging) blows up the AST and the pretty-print buffers into gigabytes of allocations. Without a cgroup memory limit, the OOM killer walks the system by RSS and can reap the tmux pane, not just dprint. `dprint check` survived (short-circuits per-file once a diff is found), `dprint fmt` did not.

## Verification (on safecube)
Before:
- \`dprint output-file-paths\` listed **762 files**
- largest file was a **1.7 MB** minified bundle

After:
- listed **300 files**
- largest file is a **36 KB** i18n JSON

## Test plan
- [ ] Re-vendor this config into a consumer repo (e.g. safecube) and run \`dprint fmt\` without crashing.
- [ ] \`dprint check\` still flags real source-tree formatting issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)