### PR TITLE
Add composite action to cache the Spotless Eclipse formatter in CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,32 @@ Install the `dprint` plugin for IntelliJ and enable it in settings.
 
 The devtools installation automatically links the necessary IDEA configuration files.
 
+### Spotless Eclipse formatter (Java)
+
+Java formatting is enforced by Spotless using the shared `.devtools/eclipse-formatter.xml`
+config (`eclipse().configFile('.devtools/eclipse-formatter.xml')` in `build.gradle`). Spotless
+resolves the Eclipse JDT formatter via Equo/P2, **downloading from `eclipse.org` at build time**.
+
+Local builds cache the artifacts after the first run, but cold CI runners re-download on every
+run — so an `eclipse.org` outage takes down every CI build (see variocube/safecube#1182).
+
+To make CI resilient, devtools ships a composite action that caches the resolved P2 artifacts.
+Add one step to your `build.yml`, right after `setup-java`:
+
+```yaml
+- uses: actions/setup-java@v4
+  with:
+    distribution: temurin
+    java-version: 21
+    cache: gradle
+- uses: ./.devtools/actions/cache-spotless-eclipse
+```
+
+The cache lives at `~/.m2/repository/dev/equo/p2-data` (where Spotless stores the Equo bundle-pool
+— not under `~/.gradle`, so `cache: gradle` does not cover it) and is keyed on the Spotless setup
+(`build.gradle`) plus `.devtools/eclipse-formatter.xml`. A cold `eclipse.org` then only affects the
+first run after a version or config bump, not every build.
+
 ## Notes
 
 **Linux users:** Leave the MySQL password empty when prompted to use sudo for root access.

--- a/actions/cache-spotless-eclipse/action.yml
+++ b/actions/cache-spotless-eclipse/action.yml
@@ -1,0 +1,21 @@
+name: Cache Spotless Eclipse formatter
+description: >-
+  Cache the Eclipse JDT formatter that Spotless resolves via Equo/P2 from
+  eclipse.org at build time. Without this, cold CI runners re-download the
+  formatter on every run, so an eclipse.org outage takes down all CI
+  (see variocube/safecube#1182). The cache is keyed on the Spotless setup
+  (build.gradle) plus the shared formatter config, so a version or config
+  bump busts it; only the first run afterwards re-fetches from eclipse.org.
+
+runs:
+  using: composite
+  steps:
+    - name: Cache Spotless Eclipse formatter (Equo P2)
+      uses: actions/cache@v4
+      with:
+        # Spotless (6.x/7.x) stores the resolved Equo P2 bundle-pool, metadata
+        # and queries here — not under ~/.gradle, so `cache: gradle` misses it.
+        path: ~/.m2/repository/dev/equo/p2-data
+        key: equo-p2-${{ runner.os }}-${{ hashFiles('build.gradle', 'build.gradle.kts', '.devtools/eclipse-formatter.xml') }}
+        restore-keys: |
+          equo-p2-${{ runner.os }}-


### PR DESCRIPTION
Follow-up to variocube/safecube#1182 ("consider applying the cache step to the shared devtools so all repos benefit").

## Background

Spotless resolves the Eclipse JDT formatter via Equo/P2, downloading from `eclipse.org` at build time. Cold CI runners re-download on every run, so an `eclipse.org` outage (as on 2026-07-05) fails **every** build in **every** repo using the shared Spotless setup.

devtools ships no CI workflow (only configs + templates), so there is no single workflow file to fix. Instead this ships a **composite action** repos can reference in one line.

## Change

- `.devtools/actions/cache-spotless-eclipse/action.yml` — wraps `actions/cache@v4` over `~/.m2/repository/dev/equo/p2-data` (verified as where Spotless 6.x/7.x stores the Equo P2 bundle-pool + metadata; **not** under `~/.gradle`, so `cache: gradle` misses it). Keyed on `build.gradle`(`.kts`) + `.devtools/eclipse-formatter.xml`.
- README section documenting the one-line usage.

## Adopting in a repo

After `./devtools.sh update`, add after `setup-java`:

```yaml
- uses: ./.devtools/actions/cache-spotless-eclipse
```

Logic stays centralized here; changes propagate via `devtools.sh update`.